### PR TITLE
fix ssl config on ormconfig.ts to allow compatibility

### DIFF
--- a/src/config/ormconfig.ts
+++ b/src/config/ormconfig.ts
@@ -34,9 +34,9 @@ export const dataSourceOptions: DataSourceOptions = {
   ],
   subscribers: [],
   migrations: [],
-  // ssl: {
-  //   rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED === 'false' ? false : true,
-  // },
+  ssl: dotEnvOptions.DB_SSL === 'true' ? {
+    rejectUnauthorized: dotEnvOptions.DB_SSL_REJECT_UNAUTHORIZED === 'false' ? false : true,
+  } : false,
 };
 
 export const AppDataSource = new DataSource(dataSourceOptions);


### PR DESCRIPTION
agrego un fix para permitir utilizar db en neon. 
se modifica solo archivo ormconfig.ts para agregar lo siguiente
ssl: dotEnvOptions.DB_SSL === 'true' ? {
    rejectUnauthorized: dotEnvOptions.DB_SSL_REJECT_UNAUTHORIZED === 'false' ? false : true,
  } : false,

NOTA: no es necesario agregar las variables de entorno DB_SSL ni DB_SSL_REJECT_UNAUTHORIZED en el .env en entornos locales por lo que el issue de ayer no debería volver a presentarse. 